### PR TITLE
Resolve a Tarefa:** [#63] - Enriquecer a resposta da API nos casos de uso de consulta de tarefas

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,6 +14,15 @@ enum TaskStatus {
   ARCHIVED
 }
 
+model TaskMember {
+  taskId         String
+  memberId       String
+
+  task           Task        @relation(fields: [taskId], references: [id], onDelete: Cascade)
+
+  @@id([taskId, memberId])
+}
+
 model Task {
   id             String      @id @default(uuid())
   title          String
@@ -25,5 +34,6 @@ model Task {
   createdAt      DateTime     @default(now())
   updatedAt      DateTime     @updatedAt
   dueDate        DateTime?
+  members        TaskMember[]
   isNotified     Boolean      @default(false)
 }

--- a/src/application/DTO/create-task.dto.ts
+++ b/src/application/DTO/create-task.dto.ts
@@ -1,8 +1,0 @@
-export interface CreateTaskDTO {
-  title: string;
-  description?: string;
-  creatorId: string;
-  groupId: string;
-  responsibleId?: string;
-  dueDate?: Date;
-}

--- a/src/application/DTO/task.dto.ts
+++ b/src/application/DTO/task.dto.ts
@@ -1,12 +1,28 @@
+export interface UserInfoDTO{
+  id: string;
+  name: string;
+}
+
 export interface TaskDTO {
   id: string;
   title: string;
   description?: string;
   status: string;
-  creatorId: string;
   groupId: string;
-  responsibleId?: string;
+  creator: UserInfoDTO;
+  responsible: UserInfoDTO;
+  members: UserInfoDTO[];
   createdAt: Date;
   updatedAt: Date;
   dueDate?: Date;
+}
+
+export interface CreateTaskDTO{
+  title: string;
+  description?: string;
+  creatorId: string;
+  groupId: string;
+  responsibleId?: string;
+  dueDate?: Date;
+  memberIds?: string[];
 }

--- a/src/application/mappers/response-dto.mapper.ts
+++ b/src/application/mappers/response-dto.mapper.ts
@@ -1,0 +1,32 @@
+import { Task } from '@/domain/task.entity';
+import { User } from '@/domain/user.entity';
+import { TaskDTO, UserInfoDTO } from '@/application/DTO/task.dto';
+
+export class TaskDTOMapper {
+  public static toDTO(
+    task: Task, 
+    creator: User | undefined, 
+    responsible: User | null | undefined,
+    members: UserInfoDTO[]
+  ): TaskDTO {
+      return {
+        id: task.id,
+        title: task.title,
+        description: task.description,
+        status: task.status,
+        groupId: task.groupId,
+        createdAt: task.createdAt,
+        updatedAt: task.updatedAt,
+        dueDate: task.dueDate,
+        creator: creator 
+          ? { id: creator.id, 
+            name: creator.name } 
+          : { id: task.creatorId, 
+            name: 'Usuário Desconhecido' },
+        responsible: responsible
+          ? { id: responsible.id, name: responsible.name }
+          : null,
+        members: members,
+      };
+  }
+}

--- a/src/application/repositories/task-repository.ts
+++ b/src/application/repositories/task-repository.ts
@@ -2,7 +2,7 @@ import { Task } from '@/domain/task.entity';
 
 export interface TaskRepository {
   create(task: Task): Promise<void>;
-  update(task: Task): Promise<void>;
+  save(task: Task): Promise<void>;
   delete(taskId: string): Promise<void>;
   findById(taskId: string): Promise<Task | null>;
   findByGroupId(groupId: string): Promise<Task[]>;

--- a/src/application/repositories/task-user-repository.ts
+++ b/src/application/repositories/task-user-repository.ts
@@ -1,0 +1,5 @@
+import { User } from '@/domain/user.entity';
+
+export interface UserRepository {
+  findManyById(ids: string[]): Promise<User[]>;
+}

--- a/src/application/services/task-enrichment.service.ts
+++ b/src/application/services/task-enrichment.service.ts
@@ -1,0 +1,40 @@
+import { Task } from '@/domain/task.entity';
+import { TaskDTO } from '@/application/DTO/task.dto';
+import { UserRepository } from '@/application/repositories/task-user-repository';
+import { TaskDTOMapper } from '@/application/mappers/response-dto.mapper';
+
+export class TaskEnrichmentService {
+  constructor(
+    private userRepository: UserRepository
+  ) {}
+
+  public async enrichTasks(tasks: Task[]): Promise<TaskDTO[]>{
+    if(tasks.length === 0)
+      return [];
+
+    const userIds = new Set<string>();
+    tasks.forEach(task =>{
+      userIds.add(task.creatorId);
+      if(task.responsibleId)
+        userIds.add(task.responsibleId);
+      if(task.memberIds) 
+        task.memberIds.forEach(id => userIds.add(id));
+    });
+
+    const users = await this.userRepository.findManyById(Array.from(userIds));
+    const usersMap = new Map(users.map(user => [user.id, user]));
+
+    return tasks.map(task => {
+      const creator = usersMap.get(task.creatorId);
+      const responsible = task.responsibleId ? usersMap.get(task.responsibleId) : undefined;
+      const members = (task.memberIds || [])
+        .map(id => usersMap.get(id))
+        .filter(Boolean)
+        .map(user => ({
+          id: user!.id,
+          name: user!.name
+        }));
+        return TaskDTOMapper.toDTO(task, creator, responsible, members);
+    });
+  }
+}

--- a/src/application/use-cases/create-task.usecase.ts
+++ b/src/application/use-cases/create-task.usecase.ts
@@ -1,23 +1,19 @@
 import { TaskRepository } from '@/application/repositories/task-repository';
-import { CreateTaskDTO} from '@/application/DTO/create-task.dto';
-import { TaskDTO } from '@/application/DTO/task.dto';
+import { CreateTaskDTO, TaskDTO } from '@/application/DTO/task.dto';
 import { Task } from '@/domain/task.entity';
 import { v4 as uuidv4 } from 'uuid';
 import { RabbitMQService } from '@/infrastructure/messaging/rabbitmq.service';
 import { config } from '@/config';
+import { TaskEnrichmentService } from '@/application/services/task-enrichment.service';
 
 export class CreateTaskUseCase {
   constructor(
     private readonly taskRepository: TaskRepository,
-    private notificationService : RabbitMQService
+    private readonly taskEnrichmentService: TaskEnrichmentService,
+    private readonly notificationService: RabbitMQService
   ) {}
 
   async execute(input: CreateTaskDTO): Promise<TaskDTO> {
-    let validDueDate: Date | null = null;
-    if (input.dueDate){
-      const parsedDate = new Date(input.dueDate);
-        validDueDate = parsedDate;
-    }
 
     const task = Task.create(
       uuidv4(),
@@ -26,8 +22,9 @@ export class CreateTaskUseCase {
       input.groupId,
       input.description,
       input.responsibleId,
-      validDueDate
-    );
+      input.dueDate,
+      input.memberIds,
+  );
 
     await this.taskRepository.create(task);
 
@@ -47,17 +44,13 @@ export class CreateTaskUseCase {
       notificationPayload
     )
 
-    return {
-      id: task.id,
-      title: task.title,
-      description: task.description,
-      status: task.status,
-      creatorId: task.creatorId,
-      groupId: task.groupId,
-      responsibleId: task.responsibleId,
-      createdAt: task.createdAt,
-      updatedAt: task.updatedAt,
-      dueDate: task.dueDate
-    };
+    const enrichedTasks = await this.taskEnrichmentService.enrichTasks([task])
+
+    if (enrichedTasks.length === 0){
+      throw new Error(
+        "Tarefa criada, mas não foi possível obter os dados do usuário.");
+    }
+
+    return enrichedTasks[0];
   }
 }

--- a/src/application/use-cases/find-task-by-due-date.usecase.ts
+++ b/src/application/use-cases/find-task-by-due-date.usecase.ts
@@ -1,15 +1,22 @@
-import { Task } from '@/domain/task.entity';
 import { TaskRepository } from '@/application/repositories/task-repository';
+import { TaskEnrichmentService } from '@/application/services/task-enrichment.service';
+import { TaskDTO } from '@/application/DTO/task.dto';
 
 export class FindTasksByDueDateUseCase {
-  constructor(private taskRepository: TaskRepository) {}
+  constructor(
+    private taskRepository: TaskRepository,
+    private taskEnrichmentService: TaskEnrichmentService,
+  ) {}
 
-  async execute(dateString: string): Promise<Task[]> {
-    const targetDate = new Date(dateString);
+  async execute(dateString: string): Promise<TaskDTO[]> {
+    const targetDate = new Date(`${dateString}T12:00:00`);
 
     if (isNaN(targetDate.getTime())) {
       throw new Error('Formato de data inválido. Por favor, use YYYY-MM-DD.');
     }
-    return this.taskRepository.findByDueTask(targetDate);
+    const tasks = await this.taskRepository.findByDueTask(targetDate);
+    const enrichedTasks = await this.taskEnrichmentService.enrichTasks(tasks);
+
+    return enrichedTasks
   }
 }

--- a/src/application/use-cases/find-task-by-group.usecase.ts
+++ b/src/application/use-cases/find-task-by-group.usecase.ts
@@ -1,10 +1,17 @@
-import { TaskRepository } from "@/application/repositories/task-repository";
+import { TaskRepository } from '@/application/repositories/task-repository';
+import { TaskEnrichmentService } from '@/application/services/task-enrichment.service';
+import { TaskDTO } from '@/application/DTO/task.dto';
 
 export class FindTasksByGroupUseCase {
-  constructor(private taskRepository: TaskRepository) {}
+  constructor(
+    private taskRepository: TaskRepository,
+    private taskEnrichementService: TaskEnrichmentService
+  ) {}
 
-  async execute(groupId: string) {
+  async execute(groupId: string): Promise<TaskDTO[]> {
     const tasks = await this.taskRepository.findByGroupId(groupId);
-    return tasks;
+    const enrichedTasks = await this.taskEnrichementService.enrichTasks(tasks);
+
+    return enrichedTasks;
   }
 }

--- a/src/application/use-cases/find-task-by-user.usecase.ts
+++ b/src/application/use-cases/find-task-by-user.usecase.ts
@@ -1,10 +1,17 @@
-import { TaskRepository } from "@/application/repositories/task-repository";
+import { TaskRepository } from '@/application/repositories/task-repository';
+import { TaskEnrichmentService } from '@/application/services/task-enrichment.service';
+import { TaskDTO } from '@/application/DTO/task.dto';
 
 export class FindTasksByUserUseCase {
-  constructor(private taskRepository: TaskRepository) {}
+  constructor(
+    private taskRepository: TaskRepository,
+    private taskEnrichmentService: TaskEnrichmentService
+  ) {}
 
-  async execute(userId: string) {
+  async execute(userId: string): Promise<TaskDTO[]> {
     const tasks = await this.taskRepository.findByUserId(userId);
-    return tasks;
+    const enrichedTasks = await this.taskEnrichmentService.enrichTasks(tasks);
+
+    return enrichedTasks;
   }
 }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -7,6 +7,9 @@ export const config = {
   server: {
     port: process.env.PORT || 3002,
   },
+  baseUrl:{
+    url: process.env.USER_BASE_URL || 'http://service_user:3000'
+  },
   rabbitMQ: {
     uri: process.env.RABBITMQ_URI || 'amqp://guest:guest@localhost:5672',
     notificationExchange: process.env.NOTIFICATION_EXCHANGE_NAME || 'notification_events',

--- a/src/domain/task.entity.ts
+++ b/src/domain/task.entity.ts
@@ -12,6 +12,7 @@ export class Task {
     public dueDate?: Date,
     public description?: string,
     public responsibleId?: string,
+    public memberIds: string[] = []
   ) {}
 
   static create(
@@ -22,6 +23,7 @@ export class Task {
     description?: string,
     responsibleId?: string,
     dueDate?: Date,
+    memberIds?: string [],
   ): Task {
     if (!title.trim()) {
       throw new Error('O título da tarefa não deve estar vazio.');
@@ -39,6 +41,7 @@ export class Task {
       dueDate,
       description,
       responsibleId,
+      memberIds || []
     );
   }
 
@@ -76,5 +79,20 @@ export class Task {
   assignResponsible(responsibleId: string): void {
     this.responsibleId = responsibleId;
     this.updatedAt = new Date();
+  }
+
+  addMember(memberId: string): void{
+    if (!this.memberIds.includes(memberId)){
+      this.memberIds.push(memberId);
+      this.updatedAt = new Date();
+    }
+  }
+
+  removeMember(memberId: string): void{
+    const memberIndex = this.memberIds.indexOf(memberId);
+    if (memberIndex > -1){
+      this.memberIds.splice(memberIndex, 1);
+      this.updatedAt = new Date();
+    }
   }
 }

--- a/src/domain/user.entity.ts
+++ b/src/domain/user.entity.ts
@@ -1,0 +1,19 @@
+export class User {
+  constructor(
+    public readonly id: string,
+    public readonly name: string,
+  ) {}
+
+  static create(
+    id: string, 
+    name: string
+  ): User {
+    if (!id || !name) { 
+      throw new Error("ID e Nome do usuário são necessários para a representação local.");
+    }
+    return new User(
+      id, 
+      name
+    );
+  }
+}

--- a/src/infrastructure/database/mappers/task-mapper.ts
+++ b/src/infrastructure/database/mappers/task-mapper.ts
@@ -1,10 +1,17 @@
-import { Task as PrismaTask } from '@prisma/client';
+import { Task as PrismaTask, TaskMember, TaskStatus as PrismaTaskStatus } from '@prisma/client';
 import { Task } from '@/domain/task.entity';
 import { TaskStatus } from '@/domain/task-status.enum';
-import { TaskStatus as PrismaTaskStatus } from '@prisma/client';
+
+type PrismaTaskWithMembers = PrismaTask & {
+  members: TaskMember[];
+};
 
 export class TaskMapper {
-  static toDomain(prismaTask: PrismaTask): Task {
+  static toDomain(prismaTask: PrismaTaskWithMembers): Task {
+    const memberIds = prismaTask.members.map(
+      member => member.memberId
+    );
+
     return new Task(
       prismaTask.id,
       prismaTask.title,
@@ -15,23 +22,9 @@ export class TaskMapper {
       prismaTask.updatedAt,
       prismaTask.dueDate,
       prismaTask.description,
-      prismaTask.responsibleId
+      prismaTask.responsibleId,
+      memberIds
     );
-  }
-
-  static toPersistence(task: Task){
-     return { 
-      id: task.id,
-      title: task.title,
-      description: task.description,
-      status: TaskMapper.statusFromPrisma(task.status),
-      creatorId: task.creatorId,
-      groupId: task.groupId,
-      responsibleId: task.responsibleId,
-      dueDate: task.dueDate,
-      createdAt: task.createdAt,
-      updatedAt: task.updatedAt,
-    };
   }
 
   static statusToPrisma(status: TaskStatus): PrismaTaskStatus {

--- a/src/infrastructure/gateways/user.gateway.ts
+++ b/src/infrastructure/gateways/user.gateway.ts
@@ -1,0 +1,25 @@
+import { UserRepository } from '@/application/repositories/task-user-repository';
+import { User } from '@/domain/user.entity'
+import axios from 'axios'
+import { config } from '@/config';
+
+export class UserGateway implements UserRepository {
+  private readonly userServiceBaseUrl: string = config.baseUrl.url;
+
+  async findManyById(id: string[]): Promise<User[]>{
+    if (id.length === 0)
+      return [];
+    try{
+      const response = await axios.get(
+        `${this.userServiceBaseUrl}/api/users/${id.join(',')}`
+      );
+      return response.data.map((
+        userData: any
+      )=> User.create(userData.id, userData.name));
+    } catch(error) {
+        console.error(`Erro ao buscar usuário ${id}:`, error);
+        return [];
+    };
+  }
+}
+

--- a/src/presentation/controllers/task.controller.ts
+++ b/src/presentation/controllers/task.controller.ts
@@ -3,9 +3,9 @@ import { CreateTaskUseCase } from '@/application/use-cases/create-task.usecase';
 import { UpdateTaskUseCase } from '@/application/use-cases/update-task.usecase';
 import { DeleteTaskUseCase } from '@/application/use-cases/delete-task.usecase';
 import { FindTasksByGroupUseCase } from '@/application/use-cases/find-task-by-group.usecase';
-import { FindTasksByUserUseCase } from "@/application/use-cases/find-task-by-user.usecase";
+import { FindTasksByUserUseCase } from '@/application/use-cases/find-task-by-user.usecase';
 import { FindTasksByDueDateUseCase } from '@/application/use-cases/find-task-by-due-date.usecase';
-import { AuthenticatedRequest } from '../middlewares/auth.middleware';
+import { AuthenticatedRequest } from '@/presentation/middlewares/auth.middleware';
 
 export class TaskController {
   constructor(
@@ -18,10 +18,9 @@ export class TaskController {
   ) {}
 
   async create(req: AuthenticatedRequest, res: Response): Promise<void> {
-    console.log('create')
-
-      const { title, description, creatorId, responsibleId, groupId, dueDate } = req.body;
-      console.log("chamouuuu",this.createTaskUseCase)
+    try {
+      const { title, description, responsibleId, groupId, dueDate, memberIds } = req.body;
+      const creatorId = req.user!.id; 
       const task = await this.createTaskUseCase.execute({
         title,
         description,
@@ -29,6 +28,7 @@ export class TaskController {
         groupId,
         responsibleId,
         dueDate,
+        memberIds
       });
 
       res.status(201).json(task);

--- a/src/presentation/routes/task.routes.ts
+++ b/src/presentation/routes/task.routes.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
-import { TaskController } from '../controllers/task.controller';
-import { authenticateAPI } from '../middlewares/auth.middleware';
+import { TaskController } from '@/presentation/controllers/task.controller';
+import { authenticateAPI } from '@/presentation/middlewares/auth.middleware';
 
 export const createTaskRoutes = (taskController: TaskController): Router => {
   const router = Router();

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,7 +4,9 @@ import { config } from './config';
 import { PrismaClient } from '@prisma/client';
 import { RabbitMQService } from '@/infrastructure/messaging/rabbitmq.service';
 import { PrismaTaskRepository } from '@/infrastructure/database/prisma-task.repository';
+import { UserGateway } from '@/infrastructure/gateways/user.gateway'
 
+import { TaskEnrichmentService } from '@/application/services/task-enrichment.service';
 import { CreateTaskUseCase } from '@/application/use-cases/create-task.usecase';
 import { UpdateTaskUseCase } from '@/application/use-cases/update-task.usecase';
 import { DeleteTaskUseCase } from '@/application/use-cases/delete-task.usecase';
@@ -24,13 +26,16 @@ async function start() {
   await rabbitMQService.start();
 
   const taskRepository = new PrismaTaskRepository(prismaClient);
+  const userGateway = new UserGateway();
 
-  const createTaskUseCase = new CreateTaskUseCase(taskRepository, rabbitMQService);
-  const updateTaskUseCase = new UpdateTaskUseCase(taskRepository, rabbitMQService);
+  const taskEnrichmentService = new TaskEnrichmentService(userGateway);
+
+  const createTaskUseCase = new CreateTaskUseCase(taskRepository, taskEnrichmentService, rabbitMQService);
+  const updateTaskUseCase = new UpdateTaskUseCase(taskRepository, taskEnrichmentService, rabbitMQService);
   const deleteTaskUseCase = new DeleteTaskUseCase(taskRepository, rabbitMQService);
-  const findTasksByGroupUseCase = new FindTasksByGroupUseCase(taskRepository);
-  const findTasksByUserUseCase = new FindTasksByUserUseCase(taskRepository);
-  const findTasksByDueDateUseCase = new FindTasksByDueDateUseCase(taskRepository);
+  const findTasksByGroupUseCase = new FindTasksByGroupUseCase(taskRepository, taskEnrichmentService);
+  const findTasksByUserUseCase = new FindTasksByUserUseCase(taskRepository, taskEnrichmentService);
+  const findTasksByDueDateUseCase = new FindTasksByDueDateUseCase(taskRepository, taskEnrichmentService);
 
   const taskController = new TaskController(
     createTaskUseCase,


### PR DESCRIPTION
Este Pull Request implementa a funcionalidade solicitada na tarefa **[#63]**, que visava enriquecer as respostas dos endpoints de consulta de tarefas (`FindBy...`) para incluir dados dos usuários (criador, responsável) em vez de apenas seus IDs.

Durante a implementação, a arquitetura foi aprimorada para ser mais robusta, escalável e consistente. Além de atender a todos os requisitos originais, **o escopo foi expandido** para incluir:

1.  **Enriquecimento em Casos de Uso de Escrita:** Os endpoints de `Create` e `Update` agora também retornam o DTO completo e enriquecido, melhorando a experiência do desenvolvedor frontend.
2.  **Gerenciamento de Membros:** Foi adicionada a capacidade de adicionar e remover múltiplos membros de uma tarefa.
3.  **Arquitetura de Microsserviços Explícita:** Foi implementado um padrão de comunicação síncrona com o microserviço de usuários, garantindo o desacoplamento e a fonte única da verdade.
4.  **Estrutura de Injeção de Dependência:** Toda a aplicação foi montada usando um padrão de injeção de dependência explícito no `server.ts`, facilitando a manutenção e os testes.

### Implementação Técnica

Conforme sugerido nas observações da tarefa, foram adotadas as seguintes estratégias arquiteturais:

* **Serviço de Enriquecimento (`TaskEnrichmentService`):**
    * Toda a lógica para enriquecer os dados foi centralizada neste serviço reutilizável.
    * Ele recebe uma lista de tarefas e orquestra a busca dos dados de todos os usuários envolvidos (criador, responsável e membros).

* **Gateway de Comunicação (`UserGateway`):**
    * Para se comunicar com o microserviço de usuários, foi criado um `UserGateway`. Ele implementa a interface `UserRepository` e é responsável por fazer as chamadas de API para o outro serviço.
    * **Performance (N+1 Query):** O gateway resolve o problema de performance fazendo uma **única chamada de API** para buscar todos os usuários necessários de uma só vez (`findManyByIds`), em vez de uma chamada por usuário.

* **Relação Many-to-Many para Membros:**
    * O schema do Prisma foi atualizado para suportar a relação de múltiplos membros por tarefa, utilizando uma tabela de junção (`TaskMember`).
    * O `PrismaTaskRepository` foi completamente refatorado para gerenciar essa relação de forma atômica nos métodos `create` e `save`.

* **Fluxo de Dados Unificado:**
    * Todos os casos de uso que interagem com o frontend (`Create`, `Update`, `Find...`) agora injetam e utilizam o `TaskEnrichmentService` para garantir que a resposta seja sempre um `TaskDTO` rico e consistente.

### Como Testar

1.  **Consulta de Tarefas (Requisito Principal):**
    * Execute uma requisição `GET` para qualquer um dos endpoints de busca (`/tasks/group/:groupId`, `/tasks/user/:userId`, `/tasks/calendar?date=...`).
    * **Verifique:** A resposta JSON deve conter os objetos `creator`, `responsible` e `members` com os campos `id` e `name`, em vez de apenas os IDs.

2.  **Criação de Tarefa:**
    * Execute uma requisição `POST` para `/tasks`, incluindo um array de `memberIds` no corpo da requisição.
    * **Verifique:** A resposta (`201 Created`) deve ser o `TaskDTO` completo e enriquecido, já incluindo os nomes dos membros que você acabou de adicionar.

3.  **Atualização de Tarefa:**
    * Execute uma requisição `PUT` para `/tasks/:taskId`.
    * No corpo, use os novos campos: `addMemberIds: ["id-de-um-usuario"]` e/ou `removeMemberIds: ["id-de-outro-usuario"]`.
    * **Verifique:** A resposta (`200 OK`) deve ser o `TaskDTO` atualizado, refletindo a nova lista de membros e com todos os nomes enriquecidos.

4.  **Verificação de Regras de Negócio:**
    * Confirme que, se uma tarefa não tiver um responsável (`responsibleId: null`), o campo `responsible` no DTO de resposta também será `null`.
